### PR TITLE
Fjernet kall til miljøer hvor IA-web ikke kjører for å unngå 404 svar

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 const lagAppnavnMedMiljø = (app, miljø) => `${app}_${miljø}`;
-const miljøer = ['t2', 't1', 'q1', 'q0', 'p'];
+const miljøer = ['t1', 'q1', 'p'];
 
 const selftestResponse = (status, data, url) => {
     return {


### PR DESCRIPTION
Monitorering sjekker miljøer hvor IA-web applikasjoner ikke kjører. Dette skaper en del unødvendige 404 response som ble fanget av andre monitorering systemer. 
Derfor har jeg slettet konfig for `q0` og `t2`. Gjenstår `t0`, `q1` og `prod` hvor IA-web kjører og som skal sjekkes og monitoreres.