### PR TITLE
Unngå epost-spam fra Github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navikt/arbeidsgiver


### PR DESCRIPTION
CODEOWNERS fører til at Github sender eposter til alle utviklere i PO arbeidsgiver. Såvidt jeg vet har ingen noen nytte av denne funksjonaliteten.